### PR TITLE
Remove the illuminate/support 4.x dependancy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0",
-        "illuminate/support": "4.0.x"
+        "php": ">=5.3.0"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
This will allow compatibility with Laravel 4.1
